### PR TITLE
Автоопределение системы в Maven

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -51,6 +51,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     needs: [Linux-Artifact, Mac-Artifact, Windows-Artifact]
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download Linux artifact
         uses: actions/download-artifact@v2
@@ -78,7 +79,6 @@ jobs:
 
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
           files: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           java-version: '17'
       - name: Build with Maven
-        run: mvn -B package -P linux --file pom.xml
+        run: mvn package
       - name: Get job's artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -26,7 +26,7 @@ jobs:
         with:
           java-version: '17'
       - name: Build with Maven
-        run: mvn -B package -P mac --file pom.xml
+        run: mvn package
       - name: Get job's artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -42,7 +42,7 @@ jobs:
         with:
           java-version: '17'
       - name: Build with Maven
-        run: mvn -B package -P win --file pom.xml
+        run: mvn package
       - name: Get job's artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <profile>
       <id>win</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <os><family>windows</family></os>
       </activation>
       <properties>
         <javafx.platform>win</javafx.platform>
@@ -28,12 +28,18 @@
     </profile>
     <profile>
       <id>linux</id>
+      <activation>
+        <os><family>unix</family></os>
+      </activation>
       <properties>
         <javafx.platform>linux</javafx.platform>
       </properties>
     </profile>
     <profile>
       <id>mac</id>
+      <activation>
+        <os><family>mac</family></os>
+      </activation>
       <properties>
         <javafx.platform>mac</javafx.platform>
       </properties>


### PR DESCRIPTION
Привет!

Изучал, что может Maven - наткнулся на статьи: [тык1](https://www.baeldung.com/maven-profiles#6-based-on-the-operating-system), [тык2](https://maven.apache.org/enforcer/enforcer-rules/requireOS.html), вспомнил про TBS: кажется это должно помочь. 

Потестил на своих Ubuntu и Mac - работает. Ну и соответственно пофиксил gh actions файл. 

Помимо этого небольшой фикс: теперь job Release запускается только если пушил с тегом (раньше job запускалась, но последний шаг не выполнялся - набаговал чуток). Это ускорило выполнение gh actions на 30 сек.  